### PR TITLE
feat(startup): add logic to start e2e metrics controller

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,14 @@ COPY Makefile Makefile
 # copy source files
 COPY cmd/ cmd/
 COPY config/ config/
+COPY controller/ controller/
+COPY pkg/ pkg/
+COPY types/ types/
+
+# we run the test once again since this is one of the
+# ways to remind copying new source packages into this 
+# build stage
+RUN make test
 
 # build binary
 RUN make

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-	https://www.apache.org/licenses/LICENSE-2.0
+    https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,5 +16,29 @@ limitations under the License.
 
 package main
 
-// main is the entry point of this binary
-func main() {}
+import (
+	"openebs.io/metac/controller/generic"
+	"openebs.io/metac/start"
+
+	"mayadata.io/e2e-metrics/controller/coverage"
+)
+
+// main function is the entry point of this binary.
+//
+// This registers various controller (i.e. kubernetes reconciler)
+// handler functions. Each handler function gets triggered due
+// to any changes (add, update or delete) to configured watch
+// resource.
+//
+// NOTE:
+// 	These functions will also be triggered in case this binary
+// gets deployed or redeployed (due to restarts, etc.).
+//
+// NOTE:
+//	One can consider each registered function as an independent
+// kubernetes controller & this project as the operator.
+func main() {
+	generic.AddToInlineRegistry("sync/pipelinecoverage", coverage.Sync)
+
+	start.Start()
+}

--- a/demo/demo.sh
+++ b/demo/demo.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+cleanup() {
+  set +e
+  
+  echo ""
+  echo "--------------------------"
+  echo "++ Clean up started"
+  echo "--------------------------"
+
+  kubectl delete -f ../deploy/operator.yaml || true
+  kubectl delete configmap metac-config-test -n e2e-metrics || true
+  kubectl delete -f ../deploy/crd.yaml || true
+  kubectl delete -f ../deploy/rbac.yaml || true
+  kubectl delete -f ../deploy/namespace.yaml || true
+
+  echo "--------------------------"
+  echo "++ Clean up completed"
+  echo "--------------------------"
+  echo ""
+}
+#trap cleanup EXIT
+
+# Uncomment this if you want to run this script in debug mode
+#set -ex
+
+echo -e "\n++ Installing e2e-metrics operator"
+
+kubectl apply -f ../deploy/namespace.yaml
+kubectl apply -f ../deploy/rbac.yaml
+kubectl apply -f ../deploy/crd.yaml
+kubectl create configmap metac-config-test -n e2e-metrics --from-file="../deploy/metac-config.yaml"
+kubectl apply -f ../deploy/operator.yaml
+
+echo -e "\n++ Installed e2e-metrics operator successfully"

--- a/deploy/crd.yaml
+++ b/deploy/crd.yaml
@@ -1,0 +1,16 @@
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: pipelinecoverages.e2e-metrics.mayadata.io
+spec:
+  group: e2e-metrics.mayadata.io
+  version: v1alpha1
+  scope: Namespaced
+  names:
+    plural: pipelinecoverages
+    singular: pipelinecoverage
+    kind: PipelineCoverage
+    shortNames:
+    - pcover
+---

--- a/deploy/metac-config.yaml
+++ b/deploy/metac-config.yaml
@@ -1,0 +1,20 @@
+apiVersion: metac.openebs.io/v1alpha1
+kind: GenericController
+metadata:
+  name: sync-namespace
+  namespace: e2e
+spec:
+  updateAny: true
+  watch:
+    apiVersion: v1
+    resource: namespaces
+  attachments:
+  - apiVersion: e2e-metrics.mayadata.io/v1alpha1
+    resource: pipelinecoverages
+    updateStrategy:
+      method: InPlace
+  hooks:
+    sync:
+      inline:
+        funcName: sync/pipelinecoverage
+---

--- a/deploy/namespace.yaml
+++ b/deploy/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: e2e-metrics

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -1,0 +1,39 @@
+---
+# This StatefulSet deploys e2e-metrics controller
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  labels:
+    app.mayadata.io/name: e2e-metrics
+  name: e2e-metrics
+  namespace: e2e-metrics
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.mayadata.io/name: e2e-metrics
+  serviceName: ""
+  template:
+    metadata:
+      labels:
+        app.mayadata.io/name: e2e-metrics
+    spec:
+      serviceAccountName: e2e-metrics
+      containers:
+      - name: e2e-metrics
+        image: quay.io/amitkumardas/e2e-metrics:latest
+        command: ["/usr/bin/e2e-metrics"]
+        args:
+        - --logtostderr
+        - --run-as-local
+        - -v=5
+        - --discovery-interval=40s
+        - --cache-flush-interval=240s
+        volumeMounts:
+        - name: config
+          mountPath: /etc/config/metac
+      volumes:
+      - name: config
+        configMap:
+          name: metac-config-test
+---

--- a/deploy/rbac.yaml
+++ b/deploy/rbac.yaml
@@ -1,0 +1,37 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: e2e-metrics
+  namespace: e2e-metrics
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: e2e-metrics
+rules:
+- apiGroups:
+  - "*"
+  resources:
+  - namespaces
+  verbs:
+  - "*"
+- apiGroups:
+  - "*"
+  resources:
+  - pipelinecoverages
+  verbs:
+  - "*"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: e2e-metrics
+subjects:
+- kind: ServiceAccount
+  name: e2e-metrics
+  namespace: e2e-metrics
+roleRef:
+  kind: ClusterRole
+  name: e2e-metrics
+  apiGroup: rbac.authorization.k8s.io
+---

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,7 @@
 cloud.google.com/go v0.26.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.34.0/go.mod h1:aQUYkXzVsufM+DwF1aE+0xfcU+56JwCaLick0ClmMTw=
 cloud.google.com/go v0.38.0/go.mod h1:990N+gfupTy94rShfmMCWGDn0LpTmnzTp2qbd1dvSRU=
+contrib.go.opencensus.io/exporter/prometheus v0.1.0 h1:SByaIoWwNgMdPSgl5sMqM2KDE5H/ukPWBRo314xiDvg=
 contrib.go.opencensus.io/exporter/prometheus v0.1.0/go.mod h1:cGFniUXGZlKRjzOyuZJ6mgB+PgBcCIa79kEKR8YCW+A=
 github.com/AmitKumarDas/metac v0.1.1-0.20200207112147-5bfc4b3f4af9 h1:gXauBusTv5CUyEEGtphAIAhFhsXrFo9YWd0ZEJs0Glw=
 github.com/AmitKumarDas/metac v0.1.1-0.20200207112147-5bfc4b3f4af9/go.mod h1:STMXa98wIYVlmc8GSmPhOjbRJar0gdYxpdyso1vE71g=
@@ -28,6 +29,7 @@ github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5
 github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
+github.com/beorn7/perks v1.0.0 h1:HWo1m869IqiPhD389kmkxeTalrjNbbJTC8LXupb+sl0=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/blang/semver v3.5.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
@@ -162,6 +164,7 @@ github.com/hashicorp/golang-lru v0.5.1 h1:0hERBMJE1eitiLkihrMvRVBYAkpHzc/J3QdDN+
 github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
+github.com/imdario/mergo v0.3.5 h1:JboBksRwiiAJWvIYJVo46AfV+IAIKZpfrSzVKj42R4Q=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
@@ -198,6 +201,7 @@ github.com/mattn/go-isatty v0.0.5/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hd
 github.com/mattn/go-isatty v0.0.7/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-isatty v0.0.8/go.mod h1:Iq45c/XA43vh69/j3iqttzPXn0bhXyGjM0Hdxcsrc5s=
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
+github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
@@ -233,13 +237,17 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/pquerna/cachecontrol v0.0.0-20171018203845-0dec1b30a021/go.mod h1:prYjPmNq4d1NPVmpShWobRqXY3q7Vp+80DqgxxUrUIA=
 github.com/prometheus/client_golang v0.9.1/go.mod h1:7SWBe2y4D6OKWSNQJUaRYU/AaXPKyh/dDVn+NZz0KFw=
 github.com/prometheus/client_golang v0.9.2/go.mod h1:OsXs2jCmiKlQ1lTBmv21f2mNfw4xf/QclQDMrYNZzcM=
+github.com/prometheus/client_golang v1.0.0 h1:vrDKnkGzuGvhNAL56c7DBz29ZL+KxnoR0x7enabFceM=
 github.com/prometheus/client_golang v1.0.0/go.mod h1:db9x61etRT2tGnBNRi70OPL5FsnadC4Ky3P0J6CfImo=
 github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910/go.mod h1:MbSGuTsp3dbXC40dX6PRTWyKYBIrTGTE9sqQNg2J8bo=
+github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90 h1:S/YWwWx/RA8rT8tKFRuGUZhuA90OyIBpPCXkcbwU8DE=
 github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/prometheus/common v0.0.0-20181126121408-4724e9255275/go.mod h1:daVV7qP5qjZbuso7PdcryaAu0sAZbrN9i7WWcTMWvro=
+github.com/prometheus/common v0.4.1 h1:K0MGApIoQvMw27RTdJkPbr3JZ7DNbtxQNyi5STVM6Kw=
 github.com/prometheus/common v0.4.1/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20181204211112-1dc9a6cbc91a/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
+github.com/prometheus/procfs v0.0.2 h1:6LJUbpNm42llc4HRCuvApCSWB/WfhuNo9K98Q9sNGfs=
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446/go.mod h1:uYEyJGbgTkfkS4+E/PavXkNJcbFIpEtjt2B0KDQ5+9M=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
@@ -282,6 +290,7 @@ go.etcd.io/etcd v0.0.0-20191023171146-3cf2f69b5738/go.mod h1:dnLIgRNXwCJa5e+c6mI
 go.mongodb.org/mongo-driver v1.0.3/go.mod h1:u7ryQJ+DOzQmeO7zB6MHyr8jkEQvC8vH7qLUO4lqsUM=
 go.mongodb.org/mongo-driver v1.1.1/go.mod h1:u7ryQJ+DOzQmeO7zB6MHyr8jkEQvC8vH7qLUO4lqsUM=
 go.mongodb.org/mongo-driver v1.1.2/go.mod h1:u7ryQJ+DOzQmeO7zB6MHyr8jkEQvC8vH7qLUO4lqsUM=
+go.opencensus.io v0.21.0 h1:mU6zScU4U1YAFPHEHYk+3JC4SY7JxgkqS10ZOSyksNg=
 go.opencensus.io v0.21.0/go.mod h1:mSImk1erAIZhrmZN+AvHh14ztQfjbGwt4TtuofqLduU=
 go.uber.org/atomic v0.0.0-20181018215023-8dc6146f7569/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=


### PR DESCRIPTION
This commit adds logic to start this controller. It also has demo & deploy related artifacts to test working of this controller.

**NOTE**: e2e-metrics controller watches for the namespace on which it is deployed _(i.e. its own  pod namespace)_ and creates the e2e coverage report. This coverage report is a k8s custom resource of kind `PipelineCoverage`.It makes use of few config files namely `.gitlab-ci.yml` & `.master-plan.yml` to calculate this coverage.

Signed-off-by: AmitKumarDas <amit.das@mayadata.io>