### PR TITLE
fix(env): add env variables to deploy artifacts

### DIFF
--- a/controller/coverage/reconciler.go
+++ b/controller/coverage/reconciler.go
@@ -259,10 +259,20 @@ func (r *Reconciler) getDesiredPipelineCoverage() *unstructured.Unstructured {
 				"id": os.Getenv("E2E_METRICS_PIPELINE_ID"),
 			},
 			"test": map[string]interface{}{
-				"count": len(r.metrics.DesiredTestCases),
+				"count": int64(len(r.metrics.DesiredTestCases)),
 			},
 		},
-		"status": map[string]interface{}{
+		// since metac does not sync the attachment's status
+		// we are renaming status -> result
+		//
+		// NOTE:
+		//	metac does not reconcile status since it can lead
+		// to hot loop reconciliations. Once metac exposes a
+		// new tunable or starts supporting reconcilining
+		// attachment's status, we may rename result -> status.
+		//
+		// ref - https://github.com/AmitKumarDas/metac/issues/100
+		"result": map[string]interface{}{
 			"phase":            r.getPhase(),
 			"reason":           r.getErrOrEmpty(),
 			"warning":          r.getWarnOrEmpty(),

--- a/controller/coverage/reconciler_test.go
+++ b/controller/coverage/reconciler_test.go
@@ -320,10 +320,10 @@ func TestReconcilerReconcile(t *testing.T) {
 							"id": "",
 						},
 						"test": map[string]interface{}{
-							"count": 0,
+							"count": int64(0),
 						},
 					},
-					"status": map[string]interface{}{
+					"result": map[string]interface{}{
 						"phase":            "Failed",
 						"reason":           "open /etc/config/e2e-metrics/: no such file or directory",
 						"warning":          "",
@@ -370,10 +370,10 @@ func TestReconcilerGetDesiredPipelineCoverage(t *testing.T) {
 							"id": "",
 						},
 						"test": map[string]interface{}{
-							"count": 0,
+							"count": int64(0),
 						},
 					},
-					"status": map[string]interface{}{
+					"result": map[string]interface{}{
 						"phase":            "Passed",
 						"reason":           "",
 						"warning":          "",

--- a/deploy/metac-config.yaml
+++ b/deploy/metac-config.yaml
@@ -8,6 +8,9 @@ spec:
   watch:
     apiVersion: v1
     resource: namespaces
+    nameSelector:
+      # we are interested in e2e-metrics namespace only
+      - e2e-metrics
   attachments:
   - apiVersion: e2e-metrics.mayadata.io/v1alpha1
     resource: pipelinecoverages

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -29,6 +29,17 @@ spec:
         - -v=5
         - --discovery-interval=40s
         - --cache-flush-interval=240s
+        env:
+        - name: MY_POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: E2E_METRICS_PIPELINE_ID
+          value: "gcp-101"
+        - name: E2E_METRICS_COVERAGE_NAME
+          value: "oep-e2e-gcp-coverage"
+        - name: E2E_METRICS_RUN_ID
+          value: "run-111"
         volumeMounts:
         - name: config
           mountPath: /etc/config/metac


### PR DESCRIPTION
This commit fixes the deploy artifacts to add missing env variables. In addition, PipelineCoverage status field is renamed to result since metac does not reconcile the status of attachments.

spec.test.count makes use of int64 instead of int since unstructured decoder treats numeric values as int64 by default. This is visible in the logs (level 5) that shows these as diff. We want to avoid un-necessary diffs leading to hot reconciliation loops.

Signed-off-by: AmitKumarDas <amit.das@mayadata.io>